### PR TITLE
Add -y to apt-get install

### DIFF
--- a/setup_spindle_environment
+++ b/setup_spindle_environment
@@ -19,7 +19,7 @@ show_usage() {
 
 ensure_installed() {
   for PKG in "$@"; do
-    dpkg --get-selections "$PKG" | grep -q "[[:space:]]install$" || apt-get install "$PKG" || die "Failed to install $PKG"
+    dpkg --get-selections "$PKG" | grep -q "[[:space:]]install$" || apt-get install -y "$PKG" || die "Failed to install $PKG"
   done
 }
 


### PR DESCRIPTION
Means no random stops in middle of script waiting for user to accept the install of a package
